### PR TITLE
Fix issues found in local audit for style guide checks

### DIFF
--- a/.custom_wordlist.txt
+++ b/.custom_wordlist.txt
@@ -1,0 +1,3 @@
+IPs
+minio
+Penpot

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,6 +11,7 @@ jobs:
       charmcraft-channel: latest/edge
       self-hosted-runner: true
       self-hosted-runner-label: "edge"
+      vale-style-check: true
   integration-tests:
     uses: canonical/operator-workflows/.github/workflows/integration_test.yaml@main
     secrets: inherit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,13 +23,11 @@ chmod +x .git/hooks/pre-commit
 This project uses `tox` for managing test environments. There are some pre-configured environments
 that can be used for linting and formatting code when you're preparing contributions to the charm:
 
-```shell
-tox run -e format        # update your code according to linting rules
-tox run -e lint          # code style
-tox run -e unit          # unit tests
-tox run -e integration   # integration tests
-tox                      # runs 'format', 'lint', and 'unit' environments
-```
+- `tox run -e format`: Update your code according to linting rules.
+- `tox run -e lint`: Runs a range of static code analysis to check the code.
+- `tox run -e unit`: Runs unit tests.
+- `tox run -e integration`: Runs integration tests.
+- `tox`: Runs `format`, `lint`, and `unit` environments.
 
 ## Build the charm
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Penpot Charm
+# Penpot charm
 
 [![CharmHub Badge](https://charmhub.io/penpot/badge.svg)](https://charmhub.io/penpot)
 [![Publish to edge](https://github.com/canonical/penpot-operator/actions/workflows/publish_charm.yaml/badge.svg)](https://github.com/canonical/penpot-operator/actions/workflows/publish_charm.yaml)
@@ -15,7 +15,9 @@ design systems at scale, and make their workflow easy and fast with ready-to-use
 
 ## Get started
 In this section, we will deploy the Penpot charm.  
+<!-- vale off -->
 You’ll need a workstation, e.g., a laptop, with sufficient resources to launch a virtual machine with 4 CPUs, 8 GB RAM, and 50 GB disk space.
+<!-- vale on -->
 
 ### Set up
 You can follow the tutorial [here](https://juju.is/docs/juju/set-up--tear-down-your-test-environment#heading--set-up-automatically) to set up a test environment for Juju with LXD.

--- a/docs/explanation/charm-architecture.md
+++ b/docs/explanation/charm-architecture.md
@@ -108,8 +108,8 @@ They are published to [Charmhub](https://charmhub.io/), the official repository 
 
 The Penpot container exposes JVM and Penpot specific metrics, including:
 
-- penpot_rpc_command_timing_*: RPC command method call timing.
-- penpot_tasks_timing_*: Background tasks timing.
+- `penpot_rpc_command_timing_*`: RPC command method call timing.
+- `penpot_tasks_timing_*`: Background tasks timing.
 
 These two metrics are used to propose a default monitoring dashboard which is visible in Grafana after [integrating with COS](https://charmhub.io/pollen/docs/how-to-relate-to-cos).
 
@@ -148,7 +148,7 @@ This will disable the user/password login in the Penpot charm and switch to usin
 
 ## Juju events
 
-The charm observes the lifecycle events ("created", "changed", "broken"...) associated to the different relations (including the peer relation). It also observes the "config_changed", "upgrade_charm" and "secret_changed" events.
+The charm observes the lifecycle events ("created", "changed", "broken"...) associated to the different relations (including the peer relation). It also observes the `config_changed`, `upgrade_charm` and `secret_changed` events.
 
 Following the [holistic](https://ops.readthedocs.io/en/latest/explanation/holistic-vs-delta-charms.html) charm approach, each of these events will trigger a "reconcile" loop.
 

--- a/docs/how-to/configure-smtp.md
+++ b/docs/how-to/configure-smtp.md
@@ -1,4 +1,6 @@
+<!-- vale off -->
 # How to configure SMTP
+<!-- vale on -->
 
 First, follow [the tutorial of `smtp-integrator`](https://charmhub.io/smtp-integrator/docs/tutorial-getting-started)
 to deploy and configure the `smtp-integrator` charm.

--- a/docs/how-to/configure-sso.md
+++ b/docs/how-to/configure-sso.md
@@ -1,4 +1,6 @@
+<!-- vale off -->
 # How to configure Single Sign-On (SSO)
+<!-- vale on -->
 
 The Penpot charm supports Single Sign-On (SSO) for user authentication 
 using OpenID Connect.

--- a/docs/how-to/integrate-with-cos.md
+++ b/docs/how-to/integrate-with-cos.md
@@ -26,7 +26,7 @@ juju integrate penpot loki-k8s
 ## Grafana
 
 In order for the Grafana dashboard to function properly, Grafana should be able to connect to
-Prometheus and Loki as its datasource. Deploy and integrate the `prometheus-k8s` and `loki-k8s`
+Prometheus and Loki as its data source. Deploy and integrate the `prometheus-k8s` and `loki-k8s`
 charms with [`grafana-k8s`](https://charmhub.io/grafana-k8s) charm through the `grafana-source` integration.
 
 Note that the relation `grafana-source` has to be explicitly stated since `prometheus-k8s` and

--- a/docs/how-to/integrate-with-cos.md
+++ b/docs/how-to/integrate-with-cos.md
@@ -2,7 +2,7 @@
 
 ## prometheus-k8s
 
-Deploy and integrate [prometheus-k8s](https://charmhub.io/prometheus-k8s) charm with the `penpot`
+Deploy and integrate [`prometheus-k8s`](https://charmhub.io/prometheus-k8s) charm with the `penpot`
 charm through the `metrics-endpoint` relation via `prometheus_scrape` interface. Prometheus should
 start scraping the metrics exposed at `:9117/metrics` endpoint.
 
@@ -13,7 +13,7 @@ juju integrate penpot prometheus-k8s
 
 ## loki-k8s
 
-Deploy and integrate [loki-k8s](https://charmhub.io/loki-k8s) charm with the `penpot` charm through
+Deploy and integrate [`loki-k8s`](https://charmhub.io/loki-k8s) charm with the `penpot` charm through
 the `logging` relation via `loki_push_api` interface. Pebble inside the 
 `penpot` container should be configured to send logs to Loki.
 
@@ -27,7 +27,7 @@ juju integrate penpot loki-k8s
 
 In order for the Grafana dashboard to function properly, Grafana should be able to connect to
 Prometheus and Loki as its datasource. Deploy and integrate the `prometheus-k8s` and `loki-k8s`
-charms with [grafana-k8s](https://charmhub.io/grafana-k8s) charm through the `grafana-source` integration.
+charms with [`grafana-k8s`](https://charmhub.io/grafana-k8s) charm through the `grafana-source` integration.
 
 Note that the relation `grafana-source` has to be explicitly stated since `prometheus-k8s` and
 `grafana-k8s` share multiple interfaces.

--- a/docs/how-to/integrate-with-cos.md
+++ b/docs/how-to/integrate-with-cos.md
@@ -1,6 +1,6 @@
 # How to integrate with COS
 
-## prometheus-k8s
+## Prometheus
 
 Deploy and integrate [`prometheus-k8s`](https://charmhub.io/prometheus-k8s) charm with the `penpot`
 charm through the `metrics-endpoint` relation via `prometheus_scrape` interface. Prometheus should
@@ -11,7 +11,7 @@ juju deploy prometheus-k8s
 juju integrate penpot prometheus-k8s
 ```
 
-## loki-k8s
+## Loki
 
 Deploy and integrate [`loki-k8s`](https://charmhub.io/loki-k8s) charm with the `penpot` charm through
 the `logging` relation via `loki_push_api` interface. Pebble inside the 
@@ -23,7 +23,7 @@ juju deploy loki-k8s
 juju integrate penpot loki-k8s
 ```
 
-## grafana-k8s
+## Grafana
 
 In order for the Grafana dashboard to function properly, Grafana should be able to connect to
 Prometheus and Loki as its datasource. Deploy and integrate the `prometheus-k8s` and `loki-k8s`

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,7 +15,7 @@ The Penpot Operator is an open-source project that welcomes community contributi
 
 |                                                                                                                                                                             |                                                                                                                                                |
 |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------|
-| [Tutorials](https://charmhub.io/penpot/docs/tutorials-getting-started)</br>  Get started - a hands-on introduction to using the Charmed Penpot operator for new users </br> | [How-to guides](https://charmhub.io/penpot/docs/how-to-how-to-configure-s3) </br> Step-by-step guides covering key operations and common tasks |
+| [Tutorials](https://charmhub.io/penpot/docs/tutorials-getting-started)</br>  Get started - a hands-on introduction to using the charm for new users </br> | [How-to guides](https://charmhub.io/penpot/docs/how-to-how-to-configure-s3) </br> Step-by-step guides covering key operations and common tasks |
 | [Reference](https://charmhub.io/penpot/docs/reference-actions) </br> Technical information - specifications, APIs, architecture                                             | [Explanation](https://charmhub.io/penpot/docs/explanation-charm-architecture) </br> Concepts - discussion and clarification of key topics      |
 
 ## Contributing to this documentation

--- a/docs/tutorial/getting-started.md
+++ b/docs/tutorial/getting-started.md
@@ -1,4 +1,6 @@
-# Tutorial: Deploy the Penpot charm
+<!-- vale off -->
+# Deploy the Penpot charm
+<!-- vale on -->
 
 ## What you'll do
 This tutorial will walk you through deploying the penpot charm; you will:
@@ -30,7 +32,9 @@ juju deploy self-signed-certificates
 juju integrate self-signed-certificates nginx-ingress-integrator
 ```
 
+<!-- vale off -->
 ## Configure Minio
+<!-- vale on -->
 1. Run `juju status` to confirm the `minio/0` unit is `active/idle` (may take a few minutes), create the `penpot` bucket:
 ```
 export AWS_ACCESS_KEY_ID=minioadmin
@@ -39,7 +43,7 @@ export AWS_ENDPOINT_URL=http://$(juju status --format=json | jq -r '.application
 aws s3 mb s3://penpot
 ```
 
-## Configure s3-integrator
+## Configure S3
 1. Run `juju status` to confirm the `s3-integrator/0` unit is `active/idle` (may take a few minutes):
 ```
 juju run s3-integrator/0 sync-s3-credentials --string-args access-key=minioadmin secret-key=minioadmin


### PR DESCRIPTION
Applicable ticket: ISD-3486

### Overview

Updates to the documentation to correct errors (and a few warnings) caught by the local audit of the Vale style checks.

### Rationale

Preparation for making the praecepta checks mandatory in our workflows.

### Juju Events Changes

None

### Module Changes

None

### Library Changes

None

### Checklist

- [X] The [charm style guide](https://juju.is/docs/sdk/styleguide) was applied
- [X] The [contributing guide](https://github.com/canonical/is-charms-contributing-guide) was applied
- [X] The changes are compliant with [ISD054 - Managing Charm Complexity](https://discourse.charmhub.io/t/specification-isd014-managing-charm-complexity/11619)
- [ ] The documentation is generated using `src-docs`
- [ ] The documentation for charmhub is updated
- [X] The PR is tagged with appropriate label (`urgent`, `trivial`, `complex`)

<!-- Explanation for any unchecked items above -->
Documentation updates on Charmhub should be handled by discourse-gatekeeper.